### PR TITLE
Change require path from amazon to thewirecuttter to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the open source PHP SDK that allows you to access the [
 The Product Advertising API PHP SDK can be installed with [Composer](https://getcomposer.org/). Run this command:
 
 ```sh
-$ composer require amazon/paapi5-php-sdk
+$ composer require thewirecutter/paapi5-php-sdk
 ```
 ## Usage
 


### PR DESCRIPTION
I tried to install this using the README, but it wasn't found under `amazon/paapi5-php-sdk`.  Switched it to `thewirecutter/paapi5-php-sdk` and it worked.

Also, [composer.json file](https://github.com/thewirecutter/product-platform/blob/ae86fe46f74522c1658ac27dbedadaaf5b4f521a/composer.json#L43) had `thewirecutter/paapi5-php-sdk`, so running `composer install` picked up on it 😄 