### PR TITLE
Suppress deprecated function notices on PHP 8.1

### DIFF
--- a/src/com/amazon/paapi5/v1/ErrorData.php
+++ b/src/com/amazon/paapi5/v1/ErrorData.php
@@ -250,6 +250,7 @@ class ErrorData implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -262,6 +263,7 @@ class ErrorData implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -275,6 +277,7 @@ class ErrorData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -291,6 +294,7 @@ class ErrorData implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/com/amazon/paapi5/v1/GetItemsRequest.php
+++ b/src/com/amazon/paapi5/v1/GetItemsRequest.php
@@ -568,6 +568,7 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -580,6 +581,7 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -593,6 +595,7 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -609,6 +612,7 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);

--- a/src/com/amazon/paapi5/v1/ProductAdvertisingAPIClientException.php
+++ b/src/com/amazon/paapi5/v1/ProductAdvertisingAPIClientException.php
@@ -220,6 +220,7 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -232,6 +233,7 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -245,6 +247,7 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -261,6 +264,7 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);


### PR DESCRIPTION
Suppress deprecated function notices when implementing ArrayAccess::offsetExists (and offsetGet, offsetSet, offsetUnset) methods by adding #[\ReturnTypeWillChange]