### PR TITLE
Update the Version Number to 1.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "thewirecutter/paapi5-php-sdk",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "ProductAdvertisingAPI 5.0 PHP SDK",
     "keywords": [
         "amazon",


### PR DESCRIPTION
1.1.1 Release
Swaps to Query::build https://github.com/thewirecutter/paapi5-php-sdk/pull/8
Supress Deprecated Function Notices https://github.com/thewirecutter/paapi5-php-sdk/pull/9