### PR TITLE
Update Package to Support PHP 8.0+ (v1.2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,3 +15,5 @@ jobs:
             - run: composer install -n --prefer-dist
 
             - run: ./vendor/bin/phpcs
+
+            - run: ./vendor/bin/phpunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,27 +4,36 @@
 #
 version: 2
 jobs:
-    build:
+    build-82:
         docker:
             # Specify the version you desire here
-            - image: circleci/php:7.1-node-browsers
+            - image: cimg/php:8.2
 
         steps:
             - checkout
 
-            # Download and cache dependencies
-            - restore_cache:
-                    keys:
-                        # "composer.lock" can be used if it is committed to the repo
-                        - v1-dependencies-{{ checksum "composer.json" }}
-                        # fallback to using the latest cache if no exact match is found
-                        - v1-dependencies-
+            - run: composer install -n --prefer-dist
+
+            - run: ./vendor/bin/phpcs
+    build-81:
+        docker:
+            # Specify the version you desire here
+            - image: cimg/php:8.1
+
+        steps:
+            - checkout
 
             - run: composer install -n --prefer-dist
 
-            - save_cache:
-                    key: v1-dependencies-{{ checksum "composer.json" }}
-                    paths:
-                        - ./vendor
+            - run: ./vendor/bin/phpcs
+    build-74:
+        docker:
+            # Specify the version you desire here
+            - image: cimg/php:7.4
+
+        steps:
+            - checkout
+
+            - run: composer install -n --prefer-dist
 
             - run: ./vendor/bin/phpcs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,3 @@ jobs:
             - run: composer install -n --prefer-dist
 
             - run: ./vendor/bin/phpcs
-    build-74:
-        docker:
-            # Specify the version you desire here
-            - image: cimg/php:7.4
-
-        steps:
-            - checkout
-
-            - run: composer install -n --prefer-dist
-
-            - run: ./vendor/bin/phpcs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,6 @@ jobs:
 
             - run: composer install -n --prefer-dist
 
-            - run: ./vendor/bin/phpcs
+            - run: composer phpcs
 
-            - run: ./vendor/bin/phpunit
+            - run: composer test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,7 @@ jobs:
     build:
         docker:
             # Specify the version you desire here
-            - image: cimg/php:8.2
-
-        steps:
-            - checkout
-
-            - run: composer install -n --prefer-dist
-
-            - run: ./vendor/bin/phpcs
-    build-81:
-        docker:
-            # Specify the version you desire here
-            - image: cimg/php:8.1
+            - image: cimg/php:8.0
 
         steps:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-    build-82:
+    build:
         docker:
             # Specify the version you desire here
             - image: cimg/php:8.2

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # OS Specific Files
 .DS_Store
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ We have not changed the API in any way, however we did cleanup portions of the c
 * Replaced usage of `\GuzzleHttp\Psr7\build_query` with `\GuzzleHttp\Psr7\Query::build` https://github.com/thewirecutter/paapi5-php-sdk/pull/8
 * Added Support for Guzzle 7 https://github.com/thewirecutter/paapi5-php-sdk/pull/6
 * Removed Deprecation Warnings when using PHP 8 https://github.com/thewirecutter/paapi5-php-sdk/pull/13
+* Removed Dynamic Property Creation Warnings when using PHP 8 https://github.com/thewirecutter/paapi5-php-sdk/pull/13
 * Updated PHP Minimum Version to PHP 8 https://github.com/thewirecutter/paapi5-php-sdk/pull/13
 * CodeSniffed to PSR-2 https://github.com/thewirecutter/paapi5-php-sdk/pull/13
 * Updated Dev Dependencies to reflect PHP 8 version requirement https://github.com/thewirecutter/paapi5-php-sdk/pull/13

--- a/README.md
+++ b/README.md
@@ -8,7 +8,18 @@ This repository contains the open source PHP SDK that allows you to access the [
 
 ## Copy of Amazon's Provided Code
 
-This is a public copy of [Amazon's provided code](https://webservices.amazon.com/paapi5/documentation/quick-start/using-sdk.html), as their version is not available through Packagist as of writing.
+This is a near identical public copy of [Amazon's provided code](https://webservices.amazon.com/paapi5/documentation/quick-start/using-sdk.html), as their version is not available through Packagist as of writing.
+
+We have not changed the API in any way, however we did cleanup portions of the code and have updated dependencies. A listing of changes are provided below.
+
+### Changes from Amazon
+
+* Replaced usage of `\GuzzleHttp\Psr7\build_query` with `\GuzzleHttp\Psr7\Query::build` https://github.com/thewirecutter/paapi5-php-sdk/pull/8
+* Added Support for Guzzle 7 https://github.com/thewirecutter/paapi5-php-sdk/pull/6
+* Removed Deprecation Warnings when using PHP 8 https://github.com/thewirecutter/paapi5-php-sdk/pull/13
+* Updated PHP Minimum Version to PHP 8 https://github.com/thewirecutter/paapi5-php-sdk/pull/13
+* CodeSniffed to PSR-2 https://github.com/thewirecutter/paapi5-php-sdk/pull/13
+* Updated Dev Dependencies to reflect PHP 8 version requirement https://github.com/thewirecutter/paapi5-php-sdk/pull/13
 
 ## Installation
 The Product Advertising API PHP SDK can be installed with [Composer](https://getcomposer.org/). The SDK is available via [Packagist](http://packagist.org/) under the [`thewirecutter/paapi5-php-sdk`](https://packagist.org/packages/thewirecutter/paapi5-php-sdk) package. If Composer is installed globally on your system, you can run the following in the base directory of your project to add the SDK as a dependency:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "~2.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "~2.6",
+        "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "~2.12"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "phpcs": "vendor/bin/phpcs --standard=phpcs.xml -n SampleGetItemsApi.php SampleSearchItemsApi.php SampleGetVariationsApi.php SampleGetBrowseNodesApi.php src/com/amazon/paapi5/v1/auth/SignHelper.php",
-        "phpcbf": "vendor/bin/phpcbf --standard=phpcs.xml -n SampleGetItemsApi.php SampleSearchItemsApi.php SampleGetVariationsApi.php SampleGetBrowseNodesApi.php src/com/amazon/paapi5/v1/auth/SignHelper.php",
+        "phpcs": "vendor/bin/phpcs --standard=PSR2 -n SampleGetItemsApi.php SampleSearchItemsApi.php SampleGetVariationsApi.php SampleGetBrowseNodesApi.php src",
+        "phpcbf": "vendor/bin/phpcbf --standard=PSR2 -n SampleGetItemsApi.php SampleSearchItemsApi.php SampleGetVariationsApi.php SampleGetBrowseNodesApi.php src",
         "php-cs-fixer": "vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --allow-risky=yes --using-cache=no --config=.php_cs SampleGetItemsApi.php SampleSearchItemsApi.php SampleGetVariationsApi.php SampleGetBrowseNodesApi.php src/com/amazon/paapi5/v1/auth/SignHelper.php"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": "^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "thewirecutter/paapi5-php-sdk",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "description": "ProductAdvertisingAPI 5.0 PHP SDK",
     "keywords": [
         "amazon",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite>
-            <directory>./test/Api</directory>
-            <directory>./test/Model</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/com/amazon/paapi5/v1/api</directory>
-            <directory suffix=".php">./src/com/amazon/paapi5/v1</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src/com/amazon/paapi5/v1/api</directory>
+      <directory suffix=".php">./src/com/amazon/paapi5/v1</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="api">
+      <directory>./test/Api</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/com/amazon/paapi5/v1/Availability.php
+++ b/src/com/amazon/paapi5/v1/Availability.php
@@ -45,5 +45,3 @@ class Availability
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Availability.php
+++ b/src/com/amazon/paapi5/v1/Availability.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/BrowseNode.php
+++ b/src/com/amazon/paapi5/v1/BrowseNode.php
@@ -401,7 +401,7 @@ class BrowseNode implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -413,7 +413,7 @@ class BrowseNode implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -426,7 +426,7 @@ class BrowseNode implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -442,7 +442,7 @@ class BrowseNode implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/BrowseNode.php
+++ b/src/com/amazon/paapi5/v1/BrowseNode.php
@@ -464,5 +464,3 @@ class BrowseNode implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/BrowseNodeAncestor.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeAncestor.php
@@ -374,5 +374,3 @@ class BrowseNodeAncestor implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/BrowseNodeAncestor.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeAncestor.php
@@ -311,7 +311,7 @@ class BrowseNodeAncestor implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class BrowseNodeAncestor implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class BrowseNodeAncestor implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class BrowseNodeAncestor implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/BrowseNodeChild.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeChild.php
@@ -344,5 +344,3 @@ class BrowseNodeChild implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/BrowseNodeChild.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeChild.php
@@ -281,7 +281,7 @@ class BrowseNodeChild implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class BrowseNodeChild implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class BrowseNodeChild implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class BrowseNodeChild implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/BrowseNodeInfo.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeInfo.php
@@ -251,7 +251,7 @@ class BrowseNodeInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class BrowseNodeInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class BrowseNodeInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class BrowseNodeInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/BrowseNodeInfo.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeInfo.php
@@ -314,5 +314,3 @@ class BrowseNodeInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/BrowseNodesResult.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodesResult.php
@@ -284,5 +284,3 @@ class BrowseNodesResult implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/BrowseNodesResult.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodesResult.php
@@ -221,7 +221,7 @@ class BrowseNodesResult implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -233,7 +233,7 @@ class BrowseNodesResult implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -246,7 +246,7 @@ class BrowseNodesResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -262,7 +262,7 @@ class BrowseNodesResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ByLineInfo.php
+++ b/src/com/amazon/paapi5/v1/ByLineInfo.php
@@ -281,7 +281,7 @@ class ByLineInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class ByLineInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class ByLineInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class ByLineInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ByLineInfo.php
+++ b/src/com/amazon/paapi5/v1/ByLineInfo.php
@@ -344,5 +344,3 @@ class ByLineInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Classifications.php
+++ b/src/com/amazon/paapi5/v1/Classifications.php
@@ -251,7 +251,7 @@ class Classifications implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class Classifications implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class Classifications implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class Classifications implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/Classifications.php
+++ b/src/com/amazon/paapi5/v1/Classifications.php
@@ -314,5 +314,3 @@ class Classifications implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Condition.php
+++ b/src/com/amazon/paapi5/v1/Condition.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/Condition.php
+++ b/src/com/amazon/paapi5/v1/Condition.php
@@ -51,5 +51,3 @@ class Condition
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ContentInfo.php
+++ b/src/com/amazon/paapi5/v1/ContentInfo.php
@@ -374,5 +374,3 @@ class ContentInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ContentInfo.php
+++ b/src/com/amazon/paapi5/v1/ContentInfo.php
@@ -311,7 +311,7 @@ class ContentInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class ContentInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class ContentInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class ContentInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ContentRating.php
+++ b/src/com/amazon/paapi5/v1/ContentRating.php
@@ -284,5 +284,3 @@ class ContentRating implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ContentRating.php
+++ b/src/com/amazon/paapi5/v1/ContentRating.php
@@ -221,7 +221,7 @@ class ContentRating implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -233,7 +233,7 @@ class ContentRating implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -246,7 +246,7 @@ class ContentRating implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -262,7 +262,7 @@ class ContentRating implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/Contributor.php
+++ b/src/com/amazon/paapi5/v1/Contributor.php
@@ -374,5 +374,3 @@ class Contributor implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Contributor.php
+++ b/src/com/amazon/paapi5/v1/Contributor.php
@@ -311,7 +311,7 @@ class Contributor implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class Contributor implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class Contributor implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class Contributor implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/CustomerReviews.php
+++ b/src/com/amazon/paapi5/v1/CustomerReviews.php
@@ -251,7 +251,7 @@ class CustomerReviews implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class CustomerReviews implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class CustomerReviews implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class CustomerReviews implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/CustomerReviews.php
+++ b/src/com/amazon/paapi5/v1/CustomerReviews.php
@@ -314,5 +314,3 @@ class CustomerReviews implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/DeliveryFlag.php
+++ b/src/com/amazon/paapi5/v1/DeliveryFlag.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/DeliveryFlag.php
+++ b/src/com/amazon/paapi5/v1/DeliveryFlag.php
@@ -49,5 +49,3 @@ class DeliveryFlag
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/DimensionBasedAttribute.php
+++ b/src/com/amazon/paapi5/v1/DimensionBasedAttribute.php
@@ -374,5 +374,3 @@ class DimensionBasedAttribute implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/DimensionBasedAttribute.php
+++ b/src/com/amazon/paapi5/v1/DimensionBasedAttribute.php
@@ -311,7 +311,7 @@ class DimensionBasedAttribute implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class DimensionBasedAttribute implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class DimensionBasedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class DimensionBasedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/DurationPrice.php
+++ b/src/com/amazon/paapi5/v1/DurationPrice.php
@@ -314,5 +314,3 @@ class DurationPrice implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/DurationPrice.php
+++ b/src/com/amazon/paapi5/v1/DurationPrice.php
@@ -251,7 +251,7 @@ class DurationPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class DurationPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class DurationPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class DurationPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ErrorData.php
+++ b/src/com/amazon/paapi5/v1/ErrorData.php
@@ -318,5 +318,3 @@ class ErrorData implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ErrorData.php
+++ b/src/com/amazon/paapi5/v1/ErrorData.php
@@ -252,7 +252,7 @@ class ErrorData implements ModelInterface, ArrayAccess
      * @return boolean
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -265,7 +265,7 @@ class ErrorData implements ModelInterface, ArrayAccess
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -279,7 +279,7 @@ class ErrorData implements ModelInterface, ArrayAccess
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -296,7 +296,7 @@ class ErrorData implements ModelInterface, ArrayAccess
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ExternalIds.php
+++ b/src/com/amazon/paapi5/v1/ExternalIds.php
@@ -344,5 +344,3 @@ class ExternalIds implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ExternalIds.php
+++ b/src/com/amazon/paapi5/v1/ExternalIds.php
@@ -281,7 +281,7 @@ class ExternalIds implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class ExternalIds implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class ExternalIds implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class ExternalIds implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/GetBrowseNodesRequest.php
+++ b/src/com/amazon/paapi5/v1/GetBrowseNodesRequest.php
@@ -443,5 +443,3 @@ class GetBrowseNodesRequest implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/GetBrowseNodesRequest.php
+++ b/src/com/amazon/paapi5/v1/GetBrowseNodesRequest.php
@@ -380,7 +380,7 @@ class GetBrowseNodesRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -392,7 +392,7 @@ class GetBrowseNodesRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -405,7 +405,7 @@ class GetBrowseNodesRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -421,7 +421,7 @@ class GetBrowseNodesRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/GetBrowseNodesResource.php
+++ b/src/com/amazon/paapi5/v1/GetBrowseNodesResource.php
@@ -45,5 +45,3 @@ class GetBrowseNodesResource
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/GetBrowseNodesResource.php
+++ b/src/com/amazon/paapi5/v1/GetBrowseNodesResource.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/GetBrowseNodesResponse.php
+++ b/src/com/amazon/paapi5/v1/GetBrowseNodesResponse.php
@@ -314,5 +314,3 @@ class GetBrowseNodesResponse implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/GetBrowseNodesResponse.php
+++ b/src/com/amazon/paapi5/v1/GetBrowseNodesResponse.php
@@ -251,7 +251,7 @@ class GetBrowseNodesResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class GetBrowseNodesResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class GetBrowseNodesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class GetBrowseNodesResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/GetItemsRequest.php
+++ b/src/com/amazon/paapi5/v1/GetItemsRequest.php
@@ -627,5 +627,3 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/GetItemsRequest.php
+++ b/src/com/amazon/paapi5/v1/GetItemsRequest.php
@@ -560,8 +560,7 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -573,8 +572,7 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -587,8 +585,7 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -604,8 +601,7 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/GetItemsResource.php
+++ b/src/com/amazon/paapi5/v1/GetItemsResource.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/GetItemsResource.php
+++ b/src/com/amazon/paapi5/v1/GetItemsResource.php
@@ -159,5 +159,3 @@ class GetItemsResource
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/GetItemsResponse.php
+++ b/src/com/amazon/paapi5/v1/GetItemsResponse.php
@@ -314,5 +314,3 @@ class GetItemsResponse implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/GetItemsResponse.php
+++ b/src/com/amazon/paapi5/v1/GetItemsResponse.php
@@ -251,7 +251,7 @@ class GetItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class GetItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class GetItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class GetItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/GetVariationsRequest.php
+++ b/src/com/amazon/paapi5/v1/GetVariationsRequest.php
@@ -653,5 +653,3 @@ class GetVariationsRequest implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/GetVariationsRequest.php
+++ b/src/com/amazon/paapi5/v1/GetVariationsRequest.php
@@ -590,7 +590,7 @@ class GetVariationsRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -602,7 +602,7 @@ class GetVariationsRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -615,7 +615,7 @@ class GetVariationsRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -631,7 +631,7 @@ class GetVariationsRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/GetVariationsResource.php
+++ b/src/com/amazon/paapi5/v1/GetVariationsResource.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/GetVariationsResource.php
+++ b/src/com/amazon/paapi5/v1/GetVariationsResource.php
@@ -165,5 +165,3 @@ class GetVariationsResource
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/GetVariationsResponse.php
+++ b/src/com/amazon/paapi5/v1/GetVariationsResponse.php
@@ -251,7 +251,7 @@ class GetVariationsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class GetVariationsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class GetVariationsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class GetVariationsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/GetVariationsResponse.php
+++ b/src/com/amazon/paapi5/v1/GetVariationsResponse.php
@@ -314,5 +314,3 @@ class GetVariationsResponse implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ImageSize.php
+++ b/src/com/amazon/paapi5/v1/ImageSize.php
@@ -281,7 +281,7 @@ class ImageSize implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class ImageSize implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class ImageSize implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class ImageSize implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ImageSize.php
+++ b/src/com/amazon/paapi5/v1/ImageSize.php
@@ -344,5 +344,3 @@ class ImageSize implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ImageType.php
+++ b/src/com/amazon/paapi5/v1/ImageType.php
@@ -281,7 +281,7 @@ class ImageType implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class ImageType implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class ImageType implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class ImageType implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ImageType.php
+++ b/src/com/amazon/paapi5/v1/ImageType.php
@@ -344,5 +344,3 @@ class ImageType implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Images.php
+++ b/src/com/amazon/paapi5/v1/Images.php
@@ -314,5 +314,3 @@ class Images implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Images.php
+++ b/src/com/amazon/paapi5/v1/Images.php
@@ -251,7 +251,7 @@ class Images implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class Images implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class Images implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class Images implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/Item.php
+++ b/src/com/amazon/paapi5/v1/Item.php
@@ -584,5 +584,3 @@ class Item implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Item.php
+++ b/src/com/amazon/paapi5/v1/Item.php
@@ -521,7 +521,7 @@ class Item implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -533,7 +533,7 @@ class Item implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -546,7 +546,7 @@ class Item implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -562,7 +562,7 @@ class Item implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ItemIdType.php
+++ b/src/com/amazon/paapi5/v1/ItemIdType.php
@@ -43,5 +43,3 @@ class ItemIdType
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ItemIdType.php
+++ b/src/com/amazon/paapi5/v1/ItemIdType.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/ItemInfo.php
+++ b/src/com/amazon/paapi5/v1/ItemInfo.php
@@ -584,5 +584,3 @@ class ItemInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ItemInfo.php
+++ b/src/com/amazon/paapi5/v1/ItemInfo.php
@@ -521,7 +521,7 @@ class ItemInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -533,7 +533,7 @@ class ItemInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -546,7 +546,7 @@ class ItemInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -562,7 +562,7 @@ class ItemInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ItemsResult.php
+++ b/src/com/amazon/paapi5/v1/ItemsResult.php
@@ -221,7 +221,7 @@ class ItemsResult implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -233,7 +233,7 @@ class ItemsResult implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -246,7 +246,7 @@ class ItemsResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -262,7 +262,7 @@ class ItemsResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ItemsResult.php
+++ b/src/com/amazon/paapi5/v1/ItemsResult.php
@@ -284,5 +284,3 @@ class ItemsResult implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/LanguageType.php
+++ b/src/com/amazon/paapi5/v1/LanguageType.php
@@ -251,7 +251,7 @@ class LanguageType implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class LanguageType implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class LanguageType implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class LanguageType implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/LanguageType.php
+++ b/src/com/amazon/paapi5/v1/LanguageType.php
@@ -314,5 +314,3 @@ class LanguageType implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Languages.php
+++ b/src/com/amazon/paapi5/v1/Languages.php
@@ -281,7 +281,7 @@ class Languages implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class Languages implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class Languages implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class Languages implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/Languages.php
+++ b/src/com/amazon/paapi5/v1/Languages.php
@@ -344,5 +344,3 @@ class Languages implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ManufactureInfo.php
+++ b/src/com/amazon/paapi5/v1/ManufactureInfo.php
@@ -281,7 +281,7 @@ class ManufactureInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class ManufactureInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class ManufactureInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class ManufactureInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ManufactureInfo.php
+++ b/src/com/amazon/paapi5/v1/ManufactureInfo.php
@@ -344,5 +344,3 @@ class ManufactureInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/MaxPrice.php
+++ b/src/com/amazon/paapi5/v1/MaxPrice.php
@@ -259,5 +259,3 @@ class MaxPrice implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/MaxPrice.php
+++ b/src/com/amazon/paapi5/v1/MaxPrice.php
@@ -196,7 +196,7 @@ class MaxPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -208,7 +208,7 @@ class MaxPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -221,7 +221,7 @@ class MaxPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -237,7 +237,7 @@ class MaxPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/Merchant.php
+++ b/src/com/amazon/paapi5/v1/Merchant.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/Merchant.php
+++ b/src/com/amazon/paapi5/v1/Merchant.php
@@ -45,5 +45,3 @@ class Merchant
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/MinPrice.php
+++ b/src/com/amazon/paapi5/v1/MinPrice.php
@@ -196,7 +196,7 @@ class MinPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -208,7 +208,7 @@ class MinPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -221,7 +221,7 @@ class MinPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -237,7 +237,7 @@ class MinPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/MinPrice.php
+++ b/src/com/amazon/paapi5/v1/MinPrice.php
@@ -259,5 +259,3 @@ class MinPrice implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/MinReviewsRating.php
+++ b/src/com/amazon/paapi5/v1/MinReviewsRating.php
@@ -196,7 +196,7 @@ class MinReviewsRating implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -208,7 +208,7 @@ class MinReviewsRating implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -221,7 +221,7 @@ class MinReviewsRating implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -237,7 +237,7 @@ class MinReviewsRating implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/MinReviewsRating.php
+++ b/src/com/amazon/paapi5/v1/MinReviewsRating.php
@@ -259,5 +259,3 @@ class MinReviewsRating implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/MinSavingPercent.php
+++ b/src/com/amazon/paapi5/v1/MinSavingPercent.php
@@ -259,5 +259,3 @@ class MinSavingPercent implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/MinSavingPercent.php
+++ b/src/com/amazon/paapi5/v1/MinSavingPercent.php
@@ -196,7 +196,7 @@ class MinSavingPercent implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -208,7 +208,7 @@ class MinSavingPercent implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -221,7 +221,7 @@ class MinSavingPercent implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -237,7 +237,7 @@ class MinSavingPercent implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/MultiValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/MultiValuedAttribute.php
@@ -344,5 +344,3 @@ class MultiValuedAttribute implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/MultiValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/MultiValuedAttribute.php
@@ -281,7 +281,7 @@ class MultiValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class MultiValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class MultiValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class MultiValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferAvailability.php
+++ b/src/com/amazon/paapi5/v1/OfferAvailability.php
@@ -311,7 +311,7 @@ class OfferAvailability implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class OfferAvailability implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class OfferAvailability implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class OfferAvailability implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferAvailability.php
+++ b/src/com/amazon/paapi5/v1/OfferAvailability.php
@@ -374,5 +374,3 @@ class OfferAvailability implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferCondition.php
+++ b/src/com/amazon/paapi5/v1/OfferCondition.php
@@ -371,7 +371,7 @@ class OfferCondition implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -383,7 +383,7 @@ class OfferCondition implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -396,7 +396,7 @@ class OfferCondition implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -412,7 +412,7 @@ class OfferCondition implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferCondition.php
+++ b/src/com/amazon/paapi5/v1/OfferCondition.php
@@ -434,5 +434,3 @@ class OfferCondition implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferConditionNote.php
+++ b/src/com/amazon/paapi5/v1/OfferConditionNote.php
@@ -314,5 +314,3 @@ class OfferConditionNote implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferConditionNote.php
+++ b/src/com/amazon/paapi5/v1/OfferConditionNote.php
@@ -251,7 +251,7 @@ class OfferConditionNote implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class OfferConditionNote implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class OfferConditionNote implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class OfferConditionNote implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferCount.php
+++ b/src/com/amazon/paapi5/v1/OfferCount.php
@@ -196,7 +196,7 @@ class OfferCount implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -208,7 +208,7 @@ class OfferCount implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -221,7 +221,7 @@ class OfferCount implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -237,7 +237,7 @@ class OfferCount implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferCount.php
+++ b/src/com/amazon/paapi5/v1/OfferCount.php
@@ -259,5 +259,3 @@ class OfferCount implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferDeliveryInfo.php
+++ b/src/com/amazon/paapi5/v1/OfferDeliveryInfo.php
@@ -374,5 +374,3 @@ class OfferDeliveryInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferDeliveryInfo.php
+++ b/src/com/amazon/paapi5/v1/OfferDeliveryInfo.php
@@ -311,7 +311,7 @@ class OfferDeliveryInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class OfferDeliveryInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class OfferDeliveryInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class OfferDeliveryInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferListing.php
+++ b/src/com/amazon/paapi5/v1/OfferListing.php
@@ -551,7 +551,7 @@ class OfferListing implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -563,7 +563,7 @@ class OfferListing implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -576,7 +576,7 @@ class OfferListing implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -592,7 +592,7 @@ class OfferListing implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferListing.php
+++ b/src/com/amazon/paapi5/v1/OfferListing.php
@@ -614,5 +614,3 @@ class OfferListing implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferLoyaltyPoints.php
+++ b/src/com/amazon/paapi5/v1/OfferLoyaltyPoints.php
@@ -221,7 +221,7 @@ class OfferLoyaltyPoints implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -233,7 +233,7 @@ class OfferLoyaltyPoints implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -246,7 +246,7 @@ class OfferLoyaltyPoints implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -262,7 +262,7 @@ class OfferLoyaltyPoints implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferLoyaltyPoints.php
+++ b/src/com/amazon/paapi5/v1/OfferLoyaltyPoints.php
@@ -284,5 +284,3 @@ class OfferLoyaltyPoints implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferMerchantInfo.php
+++ b/src/com/amazon/paapi5/v1/OfferMerchantInfo.php
@@ -404,5 +404,3 @@ class OfferMerchantInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferMerchantInfo.php
+++ b/src/com/amazon/paapi5/v1/OfferMerchantInfo.php
@@ -341,7 +341,7 @@ class OfferMerchantInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -353,7 +353,7 @@ class OfferMerchantInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -366,7 +366,7 @@ class OfferMerchantInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -382,7 +382,7 @@ class OfferMerchantInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferPrice.php
+++ b/src/com/amazon/paapi5/v1/OfferPrice.php
@@ -464,5 +464,3 @@ class OfferPrice implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferPrice.php
+++ b/src/com/amazon/paapi5/v1/OfferPrice.php
@@ -401,7 +401,7 @@ class OfferPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset) : bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -413,7 +413,7 @@ class OfferPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset) : mixed
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -426,7 +426,7 @@ class OfferPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value) : void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -442,7 +442,7 @@ class OfferPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset) : void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferProgramEligibility.php
+++ b/src/com/amazon/paapi5/v1/OfferProgramEligibility.php
@@ -314,5 +314,3 @@ class OfferProgramEligibility implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferProgramEligibility.php
+++ b/src/com/amazon/paapi5/v1/OfferProgramEligibility.php
@@ -1,4 +1,4 @@
-<?php
+s<?php
 
 /**
  * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -251,7 +251,7 @@ class OfferProgramEligibility implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class OfferProgramEligibility implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class OfferProgramEligibility implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class OfferProgramEligibility implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferPromotion.php
+++ b/src/com/amazon/paapi5/v1/OfferPromotion.php
@@ -434,5 +434,3 @@ class OfferPromotion implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferPromotion.php
+++ b/src/com/amazon/paapi5/v1/OfferPromotion.php
@@ -371,7 +371,7 @@ class OfferPromotion implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -383,7 +383,7 @@ class OfferPromotion implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -396,7 +396,7 @@ class OfferPromotion implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -412,7 +412,7 @@ class OfferPromotion implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferSavings.php
+++ b/src/com/amazon/paapi5/v1/OfferSavings.php
@@ -341,7 +341,7 @@ class OfferSavings implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -353,7 +353,7 @@ class OfferSavings implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -366,7 +366,7 @@ class OfferSavings implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -382,7 +382,7 @@ class OfferSavings implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferSavings.php
+++ b/src/com/amazon/paapi5/v1/OfferSavings.php
@@ -404,5 +404,3 @@ class OfferSavings implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferShippingCharge.php
+++ b/src/com/amazon/paapi5/v1/OfferShippingCharge.php
@@ -341,7 +341,7 @@ class OfferShippingCharge implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -353,7 +353,7 @@ class OfferShippingCharge implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -366,7 +366,7 @@ class OfferShippingCharge implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -382,7 +382,7 @@ class OfferShippingCharge implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferShippingCharge.php
+++ b/src/com/amazon/paapi5/v1/OfferShippingCharge.php
@@ -404,5 +404,3 @@ class OfferShippingCharge implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferSubCondition.php
+++ b/src/com/amazon/paapi5/v1/OfferSubCondition.php
@@ -374,5 +374,3 @@ class OfferSubCondition implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/OfferSubCondition.php
+++ b/src/com/amazon/paapi5/v1/OfferSubCondition.php
@@ -311,7 +311,7 @@ class OfferSubCondition implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class OfferSubCondition implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class OfferSubCondition implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class OfferSubCondition implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferSummary.php
+++ b/src/com/amazon/paapi5/v1/OfferSummary.php
@@ -311,7 +311,7 @@ class OfferSummary implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class OfferSummary implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class OfferSummary implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class OfferSummary implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/OfferSummary.php
+++ b/src/com/amazon/paapi5/v1/OfferSummary.php
@@ -374,5 +374,3 @@ class OfferSummary implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Offers.php
+++ b/src/com/amazon/paapi5/v1/Offers.php
@@ -314,5 +314,3 @@ class Offers implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Offers.php
+++ b/src/com/amazon/paapi5/v1/Offers.php
@@ -251,7 +251,7 @@ class Offers implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class Offers implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class Offers implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class Offers implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/PartnerType.php
+++ b/src/com/amazon/paapi5/v1/PartnerType.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/PartnerType.php
+++ b/src/com/amazon/paapi5/v1/PartnerType.php
@@ -43,5 +43,3 @@ class PartnerType
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Price.php
+++ b/src/com/amazon/paapi5/v1/Price.php
@@ -314,5 +314,3 @@ class Price implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Price.php
+++ b/src/com/amazon/paapi5/v1/Price.php
@@ -251,7 +251,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class Price implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/PriceType.php
+++ b/src/com/amazon/paapi5/v1/PriceType.php
@@ -49,5 +49,3 @@ class PriceType
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/PriceType.php
+++ b/src/com/amazon/paapi5/v1/PriceType.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/ProductAdvertisingAPIClientException.php
+++ b/src/com/amazon/paapi5/v1/ProductAdvertisingAPIClientException.php
@@ -288,5 +288,3 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ProductAdvertisingAPIClientException.php
+++ b/src/com/amazon/paapi5/v1/ProductAdvertisingAPIClientException.php
@@ -221,8 +221,7 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -234,8 +233,7 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
      *
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -248,8 +246,7 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -265,8 +262,7 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ProductAdvertisingAPIServiceException.php
+++ b/src/com/amazon/paapi5/v1/ProductAdvertisingAPIServiceException.php
@@ -284,5 +284,3 @@ class ProductAdvertisingAPIServiceException implements ModelInterface, ArrayAcce
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/ProductAdvertisingAPIServiceException.php
+++ b/src/com/amazon/paapi5/v1/ProductAdvertisingAPIServiceException.php
@@ -221,7 +221,7 @@ class ProductAdvertisingAPIServiceException implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -233,7 +233,7 @@ class ProductAdvertisingAPIServiceException implements ModelInterface, ArrayAcce
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -246,7 +246,7 @@ class ProductAdvertisingAPIServiceException implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -262,7 +262,7 @@ class ProductAdvertisingAPIServiceException implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ProductInfo.php
+++ b/src/com/amazon/paapi5/v1/ProductInfo.php
@@ -371,7 +371,7 @@ class ProductInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -383,7 +383,7 @@ class ProductInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -396,7 +396,7 @@ class ProductInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -412,7 +412,7 @@ class ProductInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/ProductInfo.php
+++ b/src/com/amazon/paapi5/v1/ProductInfo.php
@@ -434,5 +434,3 @@ class ProductInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Properties.php
+++ b/src/com/amazon/paapi5/v1/Properties.php
@@ -196,7 +196,7 @@ class Properties implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -208,7 +208,7 @@ class Properties implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -221,7 +221,7 @@ class Properties implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -237,7 +237,7 @@ class Properties implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/Properties.php
+++ b/src/com/amazon/paapi5/v1/Properties.php
@@ -259,5 +259,3 @@ class Properties implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Rating.php
+++ b/src/com/amazon/paapi5/v1/Rating.php
@@ -284,5 +284,3 @@ class Rating implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Rating.php
+++ b/src/com/amazon/paapi5/v1/Rating.php
@@ -221,7 +221,7 @@ class Rating implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -233,7 +233,7 @@ class Rating implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -246,7 +246,7 @@ class Rating implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -262,7 +262,7 @@ class Rating implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/Refinement.php
+++ b/src/com/amazon/paapi5/v1/Refinement.php
@@ -344,5 +344,3 @@ class Refinement implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/Refinement.php
+++ b/src/com/amazon/paapi5/v1/Refinement.php
@@ -281,7 +281,7 @@ class Refinement implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class Refinement implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class Refinement implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class Refinement implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/RefinementBin.php
+++ b/src/com/amazon/paapi5/v1/RefinementBin.php
@@ -314,5 +314,3 @@ class RefinementBin implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/RefinementBin.php
+++ b/src/com/amazon/paapi5/v1/RefinementBin.php
@@ -251,7 +251,7 @@ class RefinementBin implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class RefinementBin implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class RefinementBin implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class RefinementBin implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/RentalOfferListing.php
+++ b/src/com/amazon/paapi5/v1/RentalOfferListing.php
@@ -434,5 +434,3 @@ class RentalOfferListing implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/RentalOfferListing.php
+++ b/src/com/amazon/paapi5/v1/RentalOfferListing.php
@@ -1,4 +1,4 @@
-<?php
+s<?php
 
 /**
  * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -371,7 +371,7 @@ class RentalOfferListing implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -383,7 +383,7 @@ class RentalOfferListing implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -396,7 +396,7 @@ class RentalOfferListing implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -412,7 +412,7 @@ class RentalOfferListing implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/RentalOffers.php
+++ b/src/com/amazon/paapi5/v1/RentalOffers.php
@@ -284,5 +284,3 @@ class RentalOffers implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/RentalOffers.php
+++ b/src/com/amazon/paapi5/v1/RentalOffers.php
@@ -221,7 +221,7 @@ class RentalOffers implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -233,7 +233,7 @@ class RentalOffers implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -246,7 +246,7 @@ class RentalOffers implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -262,7 +262,7 @@ class RentalOffers implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/SearchItemsRequest.php
+++ b/src/com/amazon/paapi5/v1/SearchItemsRequest.php
@@ -1070,5 +1070,3 @@ class SearchItemsRequest implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/SearchItemsRequest.php
+++ b/src/com/amazon/paapi5/v1/SearchItemsRequest.php
@@ -1007,7 +1007,7 @@ class SearchItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -1019,7 +1019,7 @@ class SearchItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -1032,7 +1032,7 @@ class SearchItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -1048,7 +1048,7 @@ class SearchItemsRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/SearchItemsResource.php
+++ b/src/com/amazon/paapi5/v1/SearchItemsResource.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/SearchItemsResource.php
+++ b/src/com/amazon/paapi5/v1/SearchItemsResource.php
@@ -161,5 +161,3 @@ class SearchItemsResource
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/SearchItemsResponse.php
+++ b/src/com/amazon/paapi5/v1/SearchItemsResponse.php
@@ -314,5 +314,3 @@ class SearchItemsResponse implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/SearchItemsResponse.php
+++ b/src/com/amazon/paapi5/v1/SearchItemsResponse.php
@@ -251,7 +251,7 @@ class SearchItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class SearchItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class SearchItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class SearchItemsResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/SearchRefinements.php
+++ b/src/com/amazon/paapi5/v1/SearchRefinements.php
@@ -281,7 +281,7 @@ class SearchRefinements implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class SearchRefinements implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class SearchRefinements implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class SearchRefinements implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/SearchRefinements.php
+++ b/src/com/amazon/paapi5/v1/SearchRefinements.php
@@ -344,5 +344,3 @@ class SearchRefinements implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/SearchResult.php
+++ b/src/com/amazon/paapi5/v1/SearchResult.php
@@ -311,7 +311,7 @@ class SearchResult implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class SearchResult implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class SearchResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class SearchResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/SearchResult.php
+++ b/src/com/amazon/paapi5/v1/SearchResult.php
@@ -374,5 +374,3 @@ class SearchResult implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/SingleBooleanValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/SingleBooleanValuedAttribute.php
@@ -281,7 +281,7 @@ class SingleBooleanValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class SingleBooleanValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class SingleBooleanValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class SingleBooleanValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/SingleBooleanValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/SingleBooleanValuedAttribute.php
@@ -344,5 +344,3 @@ class SingleBooleanValuedAttribute implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/SingleIntegerValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/SingleIntegerValuedAttribute.php
@@ -281,7 +281,7 @@ class SingleIntegerValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class SingleIntegerValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class SingleIntegerValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class SingleIntegerValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/SingleIntegerValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/SingleIntegerValuedAttribute.php
@@ -344,5 +344,3 @@ class SingleIntegerValuedAttribute implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/SingleStringValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/SingleStringValuedAttribute.php
@@ -344,5 +344,3 @@ class SingleStringValuedAttribute implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/SingleStringValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/SingleStringValuedAttribute.php
@@ -281,7 +281,7 @@ class SingleStringValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class SingleStringValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class SingleStringValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class SingleStringValuedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/SortBy.php
+++ b/src/com/amazon/paapi5/v1/SortBy.php
@@ -53,5 +53,3 @@ class SortBy
         ];
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/SortBy.php
+++ b/src/com/amazon/paapi5/v1/SortBy.php
@@ -16,6 +16,7 @@
  */
 
 namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1;
+
 use \Amazon\ProductAdvertisingAPI\v1\ObjectSerializer;
 
 /**

--- a/src/com/amazon/paapi5/v1/TechnicalInfo.php
+++ b/src/com/amazon/paapi5/v1/TechnicalInfo.php
@@ -251,7 +251,7 @@ class TechnicalInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class TechnicalInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class TechnicalInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class TechnicalInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/TechnicalInfo.php
+++ b/src/com/amazon/paapi5/v1/TechnicalInfo.php
@@ -314,5 +314,3 @@ class TechnicalInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/TradeInInfo.php
+++ b/src/com/amazon/paapi5/v1/TradeInInfo.php
@@ -314,5 +314,3 @@ class TradeInInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/TradeInInfo.php
+++ b/src/com/amazon/paapi5/v1/TradeInInfo.php
@@ -251,7 +251,7 @@ class TradeInInfo implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class TradeInInfo implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class TradeInInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class TradeInInfo implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/TradeInPrice.php
+++ b/src/com/amazon/paapi5/v1/TradeInPrice.php
@@ -281,7 +281,7 @@ class TradeInPrice implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -293,7 +293,7 @@ class TradeInPrice implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -306,7 +306,7 @@ class TradeInPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -322,7 +322,7 @@ class TradeInPrice implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/TradeInPrice.php
+++ b/src/com/amazon/paapi5/v1/TradeInPrice.php
@@ -344,5 +344,3 @@ class TradeInPrice implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/UnitBasedAttribute.php
+++ b/src/com/amazon/paapi5/v1/UnitBasedAttribute.php
@@ -311,7 +311,7 @@ class UnitBasedAttribute implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class UnitBasedAttribute implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class UnitBasedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class UnitBasedAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/UnitBasedAttribute.php
+++ b/src/com/amazon/paapi5/v1/UnitBasedAttribute.php
@@ -374,5 +374,3 @@ class UnitBasedAttribute implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/VariationAttribute.php
+++ b/src/com/amazon/paapi5/v1/VariationAttribute.php
@@ -251,7 +251,7 @@ class VariationAttribute implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class VariationAttribute implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class VariationAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class VariationAttribute implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/VariationAttribute.php
+++ b/src/com/amazon/paapi5/v1/VariationAttribute.php
@@ -314,5 +314,3 @@ class VariationAttribute implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/VariationDimension.php
+++ b/src/com/amazon/paapi5/v1/VariationDimension.php
@@ -311,7 +311,7 @@ class VariationDimension implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class VariationDimension implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class VariationDimension implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class VariationDimension implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/VariationDimension.php
+++ b/src/com/amazon/paapi5/v1/VariationDimension.php
@@ -374,5 +374,3 @@ class VariationDimension implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/VariationSummary.php
+++ b/src/com/amazon/paapi5/v1/VariationSummary.php
@@ -311,7 +311,7 @@ class VariationSummary implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class VariationSummary implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class VariationSummary implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class VariationSummary implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/VariationSummary.php
+++ b/src/com/amazon/paapi5/v1/VariationSummary.php
@@ -374,5 +374,3 @@ class VariationSummary implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/VariationsResult.php
+++ b/src/com/amazon/paapi5/v1/VariationsResult.php
@@ -251,7 +251,7 @@ class VariationsResult implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -263,7 +263,7 @@ class VariationsResult implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -276,7 +276,7 @@ class VariationsResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -292,7 +292,7 @@ class VariationsResult implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/VariationsResult.php
+++ b/src/com/amazon/paapi5/v1/VariationsResult.php
@@ -314,5 +314,3 @@ class VariationsResult implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/WebsiteSalesRank.php
+++ b/src/com/amazon/paapi5/v1/WebsiteSalesRank.php
@@ -374,5 +374,3 @@ class WebsiteSalesRank implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/com/amazon/paapi5/v1/WebsiteSalesRank.php
+++ b/src/com/amazon/paapi5/v1/WebsiteSalesRank.php
@@ -311,7 +311,7 @@ class WebsiteSalesRank implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -323,7 +323,7 @@ class WebsiteSalesRank implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
@@ -336,7 +336,7 @@ class WebsiteSalesRank implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -352,7 +352,7 @@ class WebsiteSalesRank implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }

--- a/src/com/amazon/paapi5/v1/api/DefaultApi.php
+++ b/src/com/amazon/paapi5/v1/api/DefaultApi.php
@@ -148,7 +148,6 @@ class DefaultApi
                 $response->getStatusCode(),
                 $response->getHeaders()
             ];
-
         } catch (ApiException $e) {
             $responseBody = json_decode($e->getResponseBody());
             switch ($e->getCode()) {
@@ -208,7 +207,7 @@ class DefaultApi
     /**
      * Operation getBrowseNodesAsync
      *
-     * 
+     *
      *
      * @param  \Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\GetBrowseNodesRequest $getBrowseNodesRequest GetBrowseNodesRequest (required)
      *
@@ -228,7 +227,7 @@ class DefaultApi
     /**
      * Operation getBrowseNodesAsyncWithHttpInfo
      *
-     * 
+     *
      *
      * @param  \Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\GetBrowseNodesRequest $getBrowseNodesRequest GetBrowseNodesRequest (required)
      *
@@ -355,10 +354,8 @@ class DefaultApi
                 }
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
-
             } elseif ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = Query::build($formParams);
@@ -460,7 +457,6 @@ class DefaultApi
                 $response->getStatusCode(),
                 $response->getHeaders()
             ];
-
         } catch (ApiException $e) {
             $responseBody = json_decode($e->getResponseBody());
             switch ($e->getCode()) {
@@ -520,7 +516,7 @@ class DefaultApi
     /**
      * Operation getItemsAsync
      *
-     * 
+     *
      *
      * @param  \Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\GetItemsRequest $getItemsRequest GetItemsRequest (required)
      *
@@ -540,7 +536,7 @@ class DefaultApi
     /**
      * Operation getItemsAsyncWithHttpInfo
      *
-     * 
+     *
      *
      * @param  \Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\GetItemsRequest $getItemsRequest GetItemsRequest (required)
      *
@@ -667,10 +663,8 @@ class DefaultApi
                 }
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
-
             } elseif ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = Query::build($formParams);
@@ -772,7 +766,6 @@ class DefaultApi
                 $response->getStatusCode(),
                 $response->getHeaders()
             ];
-
         } catch (ApiException $e) {
             $responseBody = json_decode($e->getResponseBody());
             switch ($e->getCode()) {
@@ -832,7 +825,7 @@ class DefaultApi
     /**
      * Operation getVariationsAsync
      *
-     * 
+     *
      *
      * @param  \Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\GetVariationsRequest $getVariationsRequest GetVariationsRequest (required)
      *
@@ -852,7 +845,7 @@ class DefaultApi
     /**
      * Operation getVariationsAsyncWithHttpInfo
      *
-     * 
+     *
      *
      * @param  \Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\GetVariationsRequest $getVariationsRequest GetVariationsRequest (required)
      *
@@ -979,10 +972,8 @@ class DefaultApi
                 }
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
-
             } elseif ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = Query::build($formParams);
@@ -1084,7 +1075,6 @@ class DefaultApi
                 $response->getStatusCode(),
                 $response->getHeaders()
             ];
-
         } catch (ApiException $e) {
             $responseBody = json_decode($e->getResponseBody());
             switch ($e->getCode()) {
@@ -1144,7 +1134,7 @@ class DefaultApi
     /**
      * Operation searchItemsAsync
      *
-     * 
+     *
      *
      * @param  \Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\SearchItemsRequest $searchItemsRequest SearchItemsRequest (required)
      *
@@ -1164,7 +1154,7 @@ class DefaultApi
     /**
      * Operation searchItemsAsyncWithHttpInfo
      *
-     * 
+     *
      *
      * @param  \Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\SearchItemsRequest $searchItemsRequest SearchItemsRequest (required)
      *
@@ -1291,10 +1281,8 @@ class DefaultApi
                 }
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
-
             } elseif ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = Query::build($formParams);

--- a/src/com/amazon/paapi5/v1/auth/SignHelper.php
+++ b/src/com/amazon/paapi5/v1/auth/SignHelper.php
@@ -26,6 +26,7 @@ namespace Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\auth;
  */
 class SignHelper
 {
+    private $config = null;
     private $host = null;
     private $accessKey = null;
     private $secretKey = null;

--- a/test/Api/DefaultApiTest.php
+++ b/test/Api/DefaultApiTest.php
@@ -17,7 +17,7 @@
 
 namespace Amazon\ProductAdvertisingAPI\v1;
 
-use Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\API\DefaultApi;
+use Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\api\DefaultApi;
 use Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\GetBrowseNodesRequest;
 use Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\GetItemsRequest;
 use Amazon\ProductAdvertisingAPI\v1\com\amazon\paapi5\v1\GetVariationsRequest;

--- a/test/Api/DefaultApiTest.php
+++ b/test/Api/DefaultApiTest.php
@@ -31,7 +31,7 @@ use GuzzleHttp;
  * @package  Amazon\ProductAdvertisingAPI\v1
  * @author   Product Advertising API team
  */
-class DefaultApiTest extends \PHPUnit_Framework_TestCase
+class DefaultApiTest extends \PHPUnit\Framework\TestCase
 {
     const DUMMY_ACCESS_KEY = 'DUMMY_ACCESS_KEY';
     const DUMMY_SECRET_KEY = 'DUMMY_SECRET_KEY';
@@ -43,28 +43,28 @@ class DefaultApiTest extends \PHPUnit_Framework_TestCase
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp()
+    public function setUp(): void
     {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
     }
 


### PR DESCRIPTION
Remove support for PHP 5/7. 

Updated CircleCI builds to install, test and code-sniff correctly on PHP 8.  

Updated all sub-classes for updated CodeSniffs, removes deprecation warnings for PHP 8, updated PHPUnit support to PHPUnit 9.0. 

Post this PR being merged, we're going to increment the version number to 1.2. 