### PR TITLE
Remove lone s

### DIFF
--- a/src/com/amazon/paapi5/v1/OfferProgramEligibility.php
+++ b/src/com/amazon/paapi5/v1/OfferProgramEligibility.php
@@ -1,4 +1,4 @@
-s<?php
+<?php
 
 /**
  * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/com/amazon/paapi5/v1/RentalOfferListing.php
+++ b/src/com/amazon/paapi5/v1/RentalOfferListing.php
@@ -1,4 +1,4 @@
-s<?php
+<?php
 
 /**
  * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
Started running into errors after the latest update - seems this lone `s` snuck in.

```
Namespace declaration statement has to be the very first statement or after any declare call in the script
```