### PR TITLE
Removes the Composer Version Identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "thewirecutter/paapi5-php-sdk",
-    "version": "1.2.0",
     "description": "ProductAdvertisingAPI 5.0 PHP SDK",
     "keywords": [
         "amazon",


### PR DESCRIPTION
Removes the version number to ensure this doesn’t need to be updated in synch with version number changes. This is recommend by Packagist: https://blog.packagist.com/tagged-a-new-release-for-composer-and-it-wont-show-up-on-packagist/