### PR TITLE
Support PHP 8.4

### DIFF
--- a/src/com/amazon/paapi5/v1/BrowseNode.php
+++ b/src/com/amazon/paapi5/v1/BrowseNode.php
@@ -192,7 +192,7 @@ class BrowseNode implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ancestor'] = isset($data['ancestor']) ? $data['ancestor'] : null;
         $this->container['children'] = isset($data['children']) ? $data['children'] : null;

--- a/src/com/amazon/paapi5/v1/BrowseNodeAncestor.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeAncestor.php
@@ -177,7 +177,7 @@ class BrowseNodeAncestor implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ancestor'] = isset($data['ancestor']) ? $data['ancestor'] : null;
         $this->container['contextFreeName'] = isset($data['contextFreeName']) ? $data['contextFreeName'] : null;

--- a/src/com/amazon/paapi5/v1/BrowseNodeChild.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeChild.php
@@ -172,7 +172,7 @@ class BrowseNodeChild implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contextFreeName'] = isset($data['contextFreeName']) ? $data['contextFreeName'] : null;
         $this->container['displayName'] = isset($data['displayName']) ? $data['displayName'] : null;

--- a/src/com/amazon/paapi5/v1/BrowseNodeInfo.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodeInfo.php
@@ -167,7 +167,7 @@ class BrowseNodeInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['browseNodes'] = isset($data['browseNodes']) ? $data['browseNodes'] : null;
         $this->container['websiteSalesRank'] = isset($data['websiteSalesRank']) ? $data['websiteSalesRank'] : null;

--- a/src/com/amazon/paapi5/v1/BrowseNodesResult.php
+++ b/src/com/amazon/paapi5/v1/BrowseNodesResult.php
@@ -162,7 +162,7 @@ class BrowseNodesResult implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['browseNodes'] = isset($data['browseNodes']) ? $data['browseNodes'] : null;
     }

--- a/src/com/amazon/paapi5/v1/ByLineInfo.php
+++ b/src/com/amazon/paapi5/v1/ByLineInfo.php
@@ -172,7 +172,7 @@ class ByLineInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['brand'] = isset($data['brand']) ? $data['brand'] : null;
         $this->container['contributors'] = isset($data['contributors']) ? $data['contributors'] : null;

--- a/src/com/amazon/paapi5/v1/Classifications.php
+++ b/src/com/amazon/paapi5/v1/Classifications.php
@@ -167,7 +167,7 @@ class Classifications implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['binding'] = isset($data['binding']) ? $data['binding'] : null;
         $this->container['productGroup'] = isset($data['productGroup']) ? $data['productGroup'] : null;

--- a/src/com/amazon/paapi5/v1/ContentInfo.php
+++ b/src/com/amazon/paapi5/v1/ContentInfo.php
@@ -177,7 +177,7 @@ class ContentInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['edition'] = isset($data['edition']) ? $data['edition'] : null;
         $this->container['languages'] = isset($data['languages']) ? $data['languages'] : null;

--- a/src/com/amazon/paapi5/v1/ContentRating.php
+++ b/src/com/amazon/paapi5/v1/ContentRating.php
@@ -162,7 +162,7 @@ class ContentRating implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['audienceRating'] = isset($data['audienceRating']) ? $data['audienceRating'] : null;
     }

--- a/src/com/amazon/paapi5/v1/Contributor.php
+++ b/src/com/amazon/paapi5/v1/Contributor.php
@@ -177,7 +177,7 @@ class Contributor implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['locale'] = isset($data['locale']) ? $data['locale'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/src/com/amazon/paapi5/v1/CustomerReviews.php
+++ b/src/com/amazon/paapi5/v1/CustomerReviews.php
@@ -167,7 +167,7 @@ class CustomerReviews implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['starRating'] = isset($data['starRating']) ? $data['starRating'] : null;

--- a/src/com/amazon/paapi5/v1/DimensionBasedAttribute.php
+++ b/src/com/amazon/paapi5/v1/DimensionBasedAttribute.php
@@ -177,7 +177,7 @@ class DimensionBasedAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['height'] = isset($data['height']) ? $data['height'] : null;
         $this->container['length'] = isset($data['length']) ? $data['length'] : null;

--- a/src/com/amazon/paapi5/v1/DurationPrice.php
+++ b/src/com/amazon/paapi5/v1/DurationPrice.php
@@ -167,7 +167,7 @@ class DurationPrice implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['price'] = isset($data['price']) ? $data['price'] : null;
         $this->container['duration'] = isset($data['duration']) ? $data['duration'] : null;

--- a/src/com/amazon/paapi5/v1/ErrorData.php
+++ b/src/com/amazon/paapi5/v1/ErrorData.php
@@ -167,7 +167,7 @@ class ErrorData implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;

--- a/src/com/amazon/paapi5/v1/ExternalIds.php
+++ b/src/com/amazon/paapi5/v1/ExternalIds.php
@@ -172,7 +172,7 @@ class ExternalIds implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['eANs'] = isset($data['eANs']) ? $data['eANs'] : null;
         $this->container['iSBNs'] = isset($data['iSBNs']) ? $data['iSBNs'] : null;

--- a/src/com/amazon/paapi5/v1/GetBrowseNodesRequest.php
+++ b/src/com/amazon/paapi5/v1/GetBrowseNodesRequest.php
@@ -187,7 +187,7 @@ class GetBrowseNodesRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['browseNodeIds'] = isset($data['browseNodeIds']) ? $data['browseNodeIds'] : null;
         $this->container['languagesOfPreference'] = isset($data['languagesOfPreference']) ? $data['languagesOfPreference'] : null;

--- a/src/com/amazon/paapi5/v1/GetBrowseNodesResponse.php
+++ b/src/com/amazon/paapi5/v1/GetBrowseNodesResponse.php
@@ -167,7 +167,7 @@ class GetBrowseNodesResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['browseNodesResult'] = isset($data['browseNodesResult']) ? $data['browseNodesResult'] : null;
         $this->container['errors'] = isset($data['errors']) ? $data['errors'] : null;

--- a/src/com/amazon/paapi5/v1/GetItemsRequest.php
+++ b/src/com/amazon/paapi5/v1/GetItemsRequest.php
@@ -217,7 +217,7 @@ class GetItemsRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['condition'] = isset($data['condition']) ? $data['condition'] : null;
         $this->container['currencyOfPreference'] = isset($data['currencyOfPreference']) ? $data['currencyOfPreference'] : null;

--- a/src/com/amazon/paapi5/v1/GetItemsResponse.php
+++ b/src/com/amazon/paapi5/v1/GetItemsResponse.php
@@ -167,7 +167,7 @@ class GetItemsResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['errors'] = isset($data['errors']) ? $data['errors'] : null;
         $this->container['itemsResult'] = isset($data['itemsResult']) ? $data['itemsResult'] : null;

--- a/src/com/amazon/paapi5/v1/GetVariationsRequest.php
+++ b/src/com/amazon/paapi5/v1/GetVariationsRequest.php
@@ -222,7 +222,7 @@ class GetVariationsRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['aSIN'] = isset($data['aSIN']) ? $data['aSIN'] : null;
         $this->container['condition'] = isset($data['condition']) ? $data['condition'] : null;

--- a/src/com/amazon/paapi5/v1/GetVariationsResponse.php
+++ b/src/com/amazon/paapi5/v1/GetVariationsResponse.php
@@ -167,7 +167,7 @@ class GetVariationsResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['errors'] = isset($data['errors']) ? $data['errors'] : null;
         $this->container['variationsResult'] = isset($data['variationsResult']) ? $data['variationsResult'] : null;

--- a/src/com/amazon/paapi5/v1/ImageSize.php
+++ b/src/com/amazon/paapi5/v1/ImageSize.php
@@ -172,7 +172,7 @@ class ImageSize implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['uRL'] = isset($data['uRL']) ? $data['uRL'] : null;
         $this->container['height'] = isset($data['height']) ? $data['height'] : null;

--- a/src/com/amazon/paapi5/v1/ImageType.php
+++ b/src/com/amazon/paapi5/v1/ImageType.php
@@ -172,7 +172,7 @@ class ImageType implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['small'] = isset($data['small']) ? $data['small'] : null;
         $this->container['medium'] = isset($data['medium']) ? $data['medium'] : null;

--- a/src/com/amazon/paapi5/v1/Images.php
+++ b/src/com/amazon/paapi5/v1/Images.php
@@ -167,7 +167,7 @@ class Images implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['primary'] = isset($data['primary']) ? $data['primary'] : null;
         $this->container['variants'] = isset($data['variants']) ? $data['variants'] : null;

--- a/src/com/amazon/paapi5/v1/Item.php
+++ b/src/com/amazon/paapi5/v1/Item.php
@@ -212,7 +212,7 @@ class Item implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['aSIN'] = isset($data['aSIN']) ? $data['aSIN'] : null;
         $this->container['browseNodeInfo'] = isset($data['browseNodeInfo']) ? $data['browseNodeInfo'] : null;

--- a/src/com/amazon/paapi5/v1/ItemInfo.php
+++ b/src/com/amazon/paapi5/v1/ItemInfo.php
@@ -212,7 +212,7 @@ class ItemInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['byLineInfo'] = isset($data['byLineInfo']) ? $data['byLineInfo'] : null;
         $this->container['classifications'] = isset($data['classifications']) ? $data['classifications'] : null;

--- a/src/com/amazon/paapi5/v1/ItemsResult.php
+++ b/src/com/amazon/paapi5/v1/ItemsResult.php
@@ -162,7 +162,7 @@ class ItemsResult implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['items'] = isset($data['items']) ? $data['items'] : null;
     }

--- a/src/com/amazon/paapi5/v1/LanguageType.php
+++ b/src/com/amazon/paapi5/v1/LanguageType.php
@@ -167,7 +167,7 @@ class LanguageType implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayValue'] = isset($data['displayValue']) ? $data['displayValue'] : null;
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;

--- a/src/com/amazon/paapi5/v1/Languages.php
+++ b/src/com/amazon/paapi5/v1/Languages.php
@@ -172,7 +172,7 @@ class Languages implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayValues'] = isset($data['displayValues']) ? $data['displayValues'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/src/com/amazon/paapi5/v1/ManufactureInfo.php
+++ b/src/com/amazon/paapi5/v1/ManufactureInfo.php
@@ -172,7 +172,7 @@ class ManufactureInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['itemPartNumber'] = isset($data['itemPartNumber']) ? $data['itemPartNumber'] : null;
         $this->container['model'] = isset($data['model']) ? $data['model'] : null;

--- a/src/com/amazon/paapi5/v1/MaxPrice.php
+++ b/src/com/amazon/paapi5/v1/MaxPrice.php
@@ -162,7 +162,7 @@ class MaxPrice implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/src/com/amazon/paapi5/v1/MinPrice.php
+++ b/src/com/amazon/paapi5/v1/MinPrice.php
@@ -162,7 +162,7 @@ class MinPrice implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/src/com/amazon/paapi5/v1/MinReviewsRating.php
+++ b/src/com/amazon/paapi5/v1/MinReviewsRating.php
@@ -162,7 +162,7 @@ class MinReviewsRating implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/src/com/amazon/paapi5/v1/MinSavingPercent.php
+++ b/src/com/amazon/paapi5/v1/MinSavingPercent.php
@@ -162,7 +162,7 @@ class MinSavingPercent implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/src/com/amazon/paapi5/v1/MultiValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/MultiValuedAttribute.php
@@ -172,7 +172,7 @@ class MultiValuedAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayValues'] = isset($data['displayValues']) ? $data['displayValues'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/src/com/amazon/paapi5/v1/OfferAvailability.php
+++ b/src/com/amazon/paapi5/v1/OfferAvailability.php
@@ -177,7 +177,7 @@ class OfferAvailability implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['maxOrderQuantity'] = isset($data['maxOrderQuantity']) ? $data['maxOrderQuantity'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;

--- a/src/com/amazon/paapi5/v1/OfferCondition.php
+++ b/src/com/amazon/paapi5/v1/OfferCondition.php
@@ -187,7 +187,7 @@ class OfferCondition implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayValue'] = isset($data['displayValue']) ? $data['displayValue'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/src/com/amazon/paapi5/v1/OfferConditionNote.php
+++ b/src/com/amazon/paapi5/v1/OfferConditionNote.php
@@ -167,7 +167,7 @@ class OfferConditionNote implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['locale'] = isset($data['locale']) ? $data['locale'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;

--- a/src/com/amazon/paapi5/v1/OfferCount.php
+++ b/src/com/amazon/paapi5/v1/OfferCount.php
@@ -162,7 +162,7 @@ class OfferCount implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/src/com/amazon/paapi5/v1/OfferDeliveryInfo.php
+++ b/src/com/amazon/paapi5/v1/OfferDeliveryInfo.php
@@ -177,7 +177,7 @@ class OfferDeliveryInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['isAmazonFulfilled'] = isset($data['isAmazonFulfilled']) ? $data['isAmazonFulfilled'] : null;
         $this->container['isFreeShippingEligible'] = isset($data['isFreeShippingEligible']) ? $data['isFreeShippingEligible'] : null;

--- a/src/com/amazon/paapi5/v1/OfferListing.php
+++ b/src/com/amazon/paapi5/v1/OfferListing.php
@@ -217,7 +217,7 @@ class OfferListing implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['availability'] = isset($data['availability']) ? $data['availability'] : null;
         $this->container['condition'] = isset($data['condition']) ? $data['condition'] : null;

--- a/src/com/amazon/paapi5/v1/OfferLoyaltyPoints.php
+++ b/src/com/amazon/paapi5/v1/OfferLoyaltyPoints.php
@@ -162,7 +162,7 @@ class OfferLoyaltyPoints implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['points'] = isset($data['points']) ? $data['points'] : null;
     }

--- a/src/com/amazon/paapi5/v1/OfferMerchantInfo.php
+++ b/src/com/amazon/paapi5/v1/OfferMerchantInfo.php
@@ -182,7 +182,7 @@ class OfferMerchantInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['defaultShippingCountry'] = isset($data['defaultShippingCountry']) ? $data['defaultShippingCountry'] : null;
         $this->container['feedbackCount'] = isset($data['feedbackCount']) ? $data['feedbackCount'] : null;

--- a/src/com/amazon/paapi5/v1/OfferPrice.php
+++ b/src/com/amazon/paapi5/v1/OfferPrice.php
@@ -192,7 +192,7 @@ class OfferPrice implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
         $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;

--- a/src/com/amazon/paapi5/v1/OfferProgramEligibility.php
+++ b/src/com/amazon/paapi5/v1/OfferProgramEligibility.php
@@ -167,7 +167,7 @@ class OfferProgramEligibility implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['isPrimeExclusive'] = isset($data['isPrimeExclusive']) ? $data['isPrimeExclusive'] : null;
         $this->container['isPrimePantry'] = isset($data['isPrimePantry']) ? $data['isPrimePantry'] : null;

--- a/src/com/amazon/paapi5/v1/OfferPromotion.php
+++ b/src/com/amazon/paapi5/v1/OfferPromotion.php
@@ -187,7 +187,7 @@ class OfferPromotion implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
         $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;

--- a/src/com/amazon/paapi5/v1/OfferSavings.php
+++ b/src/com/amazon/paapi5/v1/OfferSavings.php
@@ -182,7 +182,7 @@ class OfferSavings implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
         $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;

--- a/src/com/amazon/paapi5/v1/OfferShippingCharge.php
+++ b/src/com/amazon/paapi5/v1/OfferShippingCharge.php
@@ -182,7 +182,7 @@ class OfferShippingCharge implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
         $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;

--- a/src/com/amazon/paapi5/v1/OfferSubCondition.php
+++ b/src/com/amazon/paapi5/v1/OfferSubCondition.php
@@ -177,7 +177,7 @@ class OfferSubCondition implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayValue'] = isset($data['displayValue']) ? $data['displayValue'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/src/com/amazon/paapi5/v1/OfferSummary.php
+++ b/src/com/amazon/paapi5/v1/OfferSummary.php
@@ -177,7 +177,7 @@ class OfferSummary implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['condition'] = isset($data['condition']) ? $data['condition'] : null;
         $this->container['highestPrice'] = isset($data['highestPrice']) ? $data['highestPrice'] : null;

--- a/src/com/amazon/paapi5/v1/Offers.php
+++ b/src/com/amazon/paapi5/v1/Offers.php
@@ -167,7 +167,7 @@ class Offers implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['listings'] = isset($data['listings']) ? $data['listings'] : null;
         $this->container['summaries'] = isset($data['summaries']) ? $data['summaries'] : null;

--- a/src/com/amazon/paapi5/v1/Price.php
+++ b/src/com/amazon/paapi5/v1/Price.php
@@ -167,7 +167,7 @@ class Price implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['highestPrice'] = isset($data['highestPrice']) ? $data['highestPrice'] : null;
         $this->container['lowestPrice'] = isset($data['lowestPrice']) ? $data['lowestPrice'] : null;

--- a/src/com/amazon/paapi5/v1/ProductAdvertisingAPIClientException.php
+++ b/src/com/amazon/paapi5/v1/ProductAdvertisingAPIClientException.php
@@ -162,7 +162,7 @@ class ProductAdvertisingAPIClientException implements ModelInterface, ArrayAcces
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['errors'] = isset($data['errors']) ? $data['errors'] : null;
     }

--- a/src/com/amazon/paapi5/v1/ProductAdvertisingAPIServiceException.php
+++ b/src/com/amazon/paapi5/v1/ProductAdvertisingAPIServiceException.php
@@ -162,7 +162,7 @@ class ProductAdvertisingAPIServiceException implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;
     }

--- a/src/com/amazon/paapi5/v1/ProductInfo.php
+++ b/src/com/amazon/paapi5/v1/ProductInfo.php
@@ -187,7 +187,7 @@ class ProductInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['color'] = isset($data['color']) ? $data['color'] : null;
         $this->container['isAdultProduct'] = isset($data['isAdultProduct']) ? $data['isAdultProduct'] : null;

--- a/src/com/amazon/paapi5/v1/Properties.php
+++ b/src/com/amazon/paapi5/v1/Properties.php
@@ -162,7 +162,7 @@ class Properties implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/src/com/amazon/paapi5/v1/Rating.php
+++ b/src/com/amazon/paapi5/v1/Rating.php
@@ -162,7 +162,7 @@ class Rating implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
     }

--- a/src/com/amazon/paapi5/v1/Refinement.php
+++ b/src/com/amazon/paapi5/v1/Refinement.php
@@ -172,7 +172,7 @@ class Refinement implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['bins'] = isset($data['bins']) ? $data['bins'] : null;
         $this->container['displayName'] = isset($data['displayName']) ? $data['displayName'] : null;

--- a/src/com/amazon/paapi5/v1/RefinementBin.php
+++ b/src/com/amazon/paapi5/v1/RefinementBin.php
@@ -167,7 +167,7 @@ class RefinementBin implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayName'] = isset($data['displayName']) ? $data['displayName'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;

--- a/src/com/amazon/paapi5/v1/RentalOfferListing.php
+++ b/src/com/amazon/paapi5/v1/RentalOfferListing.php
@@ -187,7 +187,7 @@ class RentalOfferListing implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['availability'] = isset($data['availability']) ? $data['availability'] : null;
         $this->container['basePrice'] = isset($data['basePrice']) ? $data['basePrice'] : null;

--- a/src/com/amazon/paapi5/v1/RentalOffers.php
+++ b/src/com/amazon/paapi5/v1/RentalOffers.php
@@ -162,7 +162,7 @@ class RentalOffers implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['listings'] = isset($data['listings']) ? $data['listings'] : null;
     }

--- a/src/com/amazon/paapi5/v1/SearchItemsRequest.php
+++ b/src/com/amazon/paapi5/v1/SearchItemsRequest.php
@@ -292,7 +292,7 @@ class SearchItemsRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['actor'] = isset($data['actor']) ? $data['actor'] : null;
         $this->container['artist'] = isset($data['artist']) ? $data['artist'] : null;

--- a/src/com/amazon/paapi5/v1/SearchItemsResponse.php
+++ b/src/com/amazon/paapi5/v1/SearchItemsResponse.php
@@ -167,7 +167,7 @@ class SearchItemsResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['searchResult'] = isset($data['searchResult']) ? $data['searchResult'] : null;
         $this->container['errors'] = isset($data['errors']) ? $data['errors'] : null;

--- a/src/com/amazon/paapi5/v1/SearchRefinements.php
+++ b/src/com/amazon/paapi5/v1/SearchRefinements.php
@@ -172,7 +172,7 @@ class SearchRefinements implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['browseNode'] = isset($data['browseNode']) ? $data['browseNode'] : null;
         $this->container['otherRefinements'] = isset($data['otherRefinements']) ? $data['otherRefinements'] : null;

--- a/src/com/amazon/paapi5/v1/SearchResult.php
+++ b/src/com/amazon/paapi5/v1/SearchResult.php
@@ -177,7 +177,7 @@ class SearchResult implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['totalResultCount'] = isset($data['totalResultCount']) ? $data['totalResultCount'] : null;
         $this->container['searchURL'] = isset($data['searchURL']) ? $data['searchURL'] : null;

--- a/src/com/amazon/paapi5/v1/SingleBooleanValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/SingleBooleanValuedAttribute.php
@@ -172,7 +172,7 @@ class SingleBooleanValuedAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayValue'] = isset($data['displayValue']) ? $data['displayValue'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/src/com/amazon/paapi5/v1/SingleIntegerValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/SingleIntegerValuedAttribute.php
@@ -172,7 +172,7 @@ class SingleIntegerValuedAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayValue'] = isset($data['displayValue']) ? $data['displayValue'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/src/com/amazon/paapi5/v1/SingleStringValuedAttribute.php
+++ b/src/com/amazon/paapi5/v1/SingleStringValuedAttribute.php
@@ -172,7 +172,7 @@ class SingleStringValuedAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayValue'] = isset($data['displayValue']) ? $data['displayValue'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/src/com/amazon/paapi5/v1/TechnicalInfo.php
+++ b/src/com/amazon/paapi5/v1/TechnicalInfo.php
@@ -167,7 +167,7 @@ class TechnicalInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['energyEfficiencyClass'] = isset($data['energyEfficiencyClass']) ? $data['energyEfficiencyClass'] : null;
         $this->container['formats'] = isset($data['formats']) ? $data['formats'] : null;

--- a/src/com/amazon/paapi5/v1/TradeInInfo.php
+++ b/src/com/amazon/paapi5/v1/TradeInInfo.php
@@ -167,7 +167,7 @@ class TradeInInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['isEligibleForTradeIn'] = isset($data['isEligibleForTradeIn']) ? $data['isEligibleForTradeIn'] : null;
         $this->container['price'] = isset($data['price']) ? $data['price'] : null;

--- a/src/com/amazon/paapi5/v1/TradeInPrice.php
+++ b/src/com/amazon/paapi5/v1/TradeInPrice.php
@@ -172,7 +172,7 @@ class TradeInPrice implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['amount'] = isset($data['amount']) ? $data['amount'] : null;
         $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;

--- a/src/com/amazon/paapi5/v1/UnitBasedAttribute.php
+++ b/src/com/amazon/paapi5/v1/UnitBasedAttribute.php
@@ -177,7 +177,7 @@ class UnitBasedAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayValue'] = isset($data['displayValue']) ? $data['displayValue'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/src/com/amazon/paapi5/v1/VariationAttribute.php
+++ b/src/com/amazon/paapi5/v1/VariationAttribute.php
@@ -167,7 +167,7 @@ class VariationAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;

--- a/src/com/amazon/paapi5/v1/VariationDimension.php
+++ b/src/com/amazon/paapi5/v1/VariationDimension.php
@@ -177,7 +177,7 @@ class VariationDimension implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['displayName'] = isset($data['displayName']) ? $data['displayName'] : null;
         $this->container['locale'] = isset($data['locale']) ? $data['locale'] : null;

--- a/src/com/amazon/paapi5/v1/VariationSummary.php
+++ b/src/com/amazon/paapi5/v1/VariationSummary.php
@@ -177,7 +177,7 @@ class VariationSummary implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['pageCount'] = isset($data['pageCount']) ? $data['pageCount'] : null;
         $this->container['price'] = isset($data['price']) ? $data['price'] : null;

--- a/src/com/amazon/paapi5/v1/VariationsResult.php
+++ b/src/com/amazon/paapi5/v1/VariationsResult.php
@@ -167,7 +167,7 @@ class VariationsResult implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['items'] = isset($data['items']) ? $data['items'] : null;
         $this->container['variationSummary'] = isset($data['variationSummary']) ? $data['variationSummary'] : null;

--- a/src/com/amazon/paapi5/v1/WebsiteSalesRank.php
+++ b/src/com/amazon/paapi5/v1/WebsiteSalesRank.php
@@ -177,7 +177,7 @@ class WebsiteSalesRank implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contextFreeName'] = isset($data['contextFreeName']) ? $data['contextFreeName'] : null;
         $this->container['displayName'] = isset($data['displayName']) ? $data['displayName'] : null;

--- a/src/com/amazon/paapi5/v1/api/DefaultApi.php
+++ b/src/com/amazon/paapi5/v1/api/DefaultApi.php
@@ -61,7 +61,7 @@ class DefaultApi
     public function __construct(
         ClientInterface $client,
         Configuration $config,
-        HeaderSelector $selector = null
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client;
         $this->config = $config;


### PR DESCRIPTION
I wanted to support PHP 8.4, so I applied [ExplicitNullableParamTypeRector](https://getrector.com/rule-detail/explicit-nullable-param-type-rector)  to suppress the deprecated error.