### PR TITLE
add Affiliate Platforms team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The default owners for this version of the Amazon Product Advertising API 5.0 SDK for PHP is the Affiliate Platforms Squad under Product Platforms at Wirecutter.
+*       @thewirecutter/affiliate-platforms-squad


### PR DESCRIPTION
To bring maintenance of this repository into alignment with other Wirecutter repositories, this pull request adds a GitHub CODEOWNERS file to clarify which team is responsible for this codebase.
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Note the [affiliate-platforms-squad](https://github.com/orgs/thewirecutter/teams/affiliate-platforms-squad) GitHub team has the appropriate access to this repository.
 
<img width="1181" height="192" alt="Screenshot 2025-11-17 at 2 43 18 PM" src="https://github.com/user-attachments/assets/6f41c281-64d1-435f-aff2-8cbc12f679c3" />
