### PR TITLE
Expose buildAuthenticatedHeaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We have not changed the API behavior in any way. A listing of our additions and 
 * Upgraded `friendsofphp/php-cs-fixer` to `^3.5` with updated `.php_cs` config.
 * Added integration tests that run the example scripts and verify they execute without any errors.
 * Added typehints to method signatures where possible (without breaking backwards compatibility).
-* Exposed the `DefaultApi`'s `buildAuthenticatedTokens()` method as protected so it can be overridden for caching tokens (see below for example).
+* Exposed the `DefaultApi`'s `buildAuthenticatedHeaders()` method as protected so it can be overridden for caching tokens (see below for example).
 
 ## Installation
 
@@ -111,7 +111,7 @@ Complete API documentation is available at [https://affiliate-program.amazon.com
 
 ## Caching Tokens
 
-The `DefaultApi` class caches OAuth2 tokens in memory for the duration of the instance. To implement a more persistent caching mechanism (e.g. file-based, Redis, etc.), you can extend `DefaultApi` and override the `buildAuthenticatedTokens()` method to first check your cache before making a request to Amazon's token endpoint.
+The `DefaultApi` class caches OAuth2 tokens in memory for the duration of the instance. To implement a more persistent caching mechanism (e.g. file-based, Redis, etc.), you can extend `DefaultApi` and override the `buildAuthenticatedHeaders()` method to first check your cache before making a request to Amazon's token endpoint.
 
 Example code snippet for improved caching:
 
@@ -119,7 +119,7 @@ Example code snippet for improved caching:
 class CachedApi extends DefaultApi
 {
     public function __construct(
-        private readonly cachingTokenManager $cachingTokenManager, // Inject the caching token manager
+        private readonly CachingTokenManager $cachingTokenManager, // Inject a caching token manager that extends OAuth2TokenManager.
         ?ClientInterface                     $client = null,
         ?Configuration                       $config = null,
         ?HeaderSelector                      $selector = null,
@@ -130,7 +130,7 @@ class CachedApi extends DefaultApi
 
     protected function buildAuthenticatedHeaders(string $resourcePath): array
     {
-        $token   = $this->cachingTokenManager->getToken(); // Get the cached token (or fetch a new one if expired)
+        $token   = $this->cachingTokenManager->getToken(); // This will use the cached token if available, or fetch a new one if not.
         $version = $this->config->getVersion();
 
         if (str_starts_with($version, '3.')) {
@@ -148,26 +148,33 @@ class CachedApi extends DefaultApi
 
 class CachingTokenManager extends OAuth2TokenManager
 {
-    // NOTE: Cache is used here as pseudocode. You can implement your own caching logic using files, Redis, Memcached, etc.
+    // $cache is any PSR-16 CacheInterface implementation (files, Redis, Memcached, etc.)
 
-    private const string CACHE_KEY = 'amazon_unique_token_cache_key'; // Use a unique cache key for your token
-    private const int CACHE_FRESH_MINUTES = 50; // Time in minutes to consider the cached token "fresh" and safe to use without triggering background refresh.
-    private const int CACHE_TTL_MINUTES = 55; // Time in minutes to consider the cached token valid before it must be refreshed (should be less than the actual token expiration time)
+    private const string CACHE_KEY = 'amazon_unique_token_cache_key'; // Use a unique cache key to avoid collisions with other cached data.
+    private const int CACHE_TTL_SECONDS = 3300; // 55 minutes — 5 minutes less than Amazon's 60 minute token expiry
+
+    public function __construct(private readonly \Psr\SimpleCache\CacheInterface $cache)
+    {
+        parent::__construct();
+    }
 
     public function getToken(): string
     {
-        // Cache::flexible() will return the cached token if it exists and is not expired.
-        // If the token is expired or doesn't exist, it will call the provided callback to fetch a new token, store it in the cache, and return it.
-        return Cache::flexible(
-            self::CACHE_KEY,
-            [now()->addMinutes(self::CACHE_FRESH_MINUTES), now()->addMinutes(self::CACHE_TTL_MINUTES)],
-            fn() => parent::getToken() // You may want to wrap parent::getToken() in a helper method that can mock the return for testing.
-        );
+        $cached = $this->cache->get(self::CACHE_KEY);
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $token = parent::getToken();
+        $this->cache->set(self::CACHE_KEY, $token, self::CACHE_TTL_SECONDS);
+
+        return $token;
     }
 
     public function clearToken(): void
     {
-        Cache::forget(self::CACHE_KEY);
+        $this->cache->delete(self::CACHE_KEY);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We have not changed the API behavior in any way. A listing of our additions and 
 * Upgraded `friendsofphp/php-cs-fixer` to `^3.5` with updated `.php_cs` config.
 * Added integration tests that run the example scripts and verify they execute without any errors.
 * Added typehints to method signatures where possible (without breaking backwards compatibility).
+* Exposed the `DefaultApi`'s `buildAuthenticatedTokens()` method as protected so it can be overridden for caching tokens (see below for example).
 
 ## Installation
 
@@ -107,6 +108,69 @@ See the `examples/` directory for additional sample scripts covering all support
 - `SampleListReports.php`
 
 Complete API documentation is available at [https://affiliate-program.amazon.com/creatorsapi](https://affiliate-program.amazon.com/creatorsapi).
+
+## Caching Tokens
+
+The `DefaultApi` class caches OAuth2 tokens in memory for the duration of the instance. To implement a more persistent caching mechanism (e.g. file-based, Redis, etc.), you can extend `DefaultApi` and override the `buildAuthenticatedTokens()` method to first check your cache before making a request to Amazon's token endpoint.
+
+Example code snippet for improved caching:
+
+```php
+class CachedApi extends DefaultApi
+{
+    public function __construct(
+        private readonly cachingTokenManager $cachingTokenManager, // Inject the caching token manager
+        ?ClientInterface                     $client = null,
+        ?Configuration                       $config = null,
+        ?HeaderSelector                      $selector = null,
+        int                                  $hostIndex = 0
+    ) {
+        parent::__construct($client, $config, $selector, $hostIndex);
+    }
+
+    protected function buildAuthenticatedHeaders(string $resourcePath): array
+    {
+        $token   = $this->cachingTokenManager->getToken(); // Get the cached token (or fetch a new one if expired)
+        $version = $this->config->getVersion();
+
+        if (str_starts_with($version, '3.')) {
+            return ['Authorization' => "Bearer {$token}"];
+        }
+
+        return ['Authorization' => "Bearer {$token}, Version {$version}"];
+    }
+
+    public function clearToken(): void
+    {
+        $this->cachingTokenManager->clearToken();
+    }
+}
+
+class CachingTokenManager extends OAuth2TokenManager
+{
+    // NOTE: Cache is used here as pseudocode. You can implement your own caching logic using files, Redis, Memcached, etc.
+
+    private const string CACHE_KEY = 'amazon_unique_token_cache_key'; // Use a unique cache key for your token
+    private const int CACHE_FRESH_MINUTES = 50; // Time in minutes to consider the cached token "fresh" and safe to use without triggering background refresh.
+    private const int CACHE_TTL_MINUTES = 55; // Time in minutes to consider the cached token valid before it must be refreshed (should be less than the actual token expiration time)
+
+    public function getToken(): string
+    {
+        // Cache::flexible() will return the cached token if it exists and is not expired.
+        // If the token is expired or doesn't exist, it will call the provided callback to fetch a new token, store it in the cache, and return it.
+        return Cache::flexible(
+            self::CACHE_KEY,
+            [now()->addMinutes(self::CACHE_FRESH_MINUTES), now()->addMinutes(self::CACHE_TTL_MINUTES)],
+            fn() => parent::getToken() // You may want to wrap parent::getToken() in a helper method that can mock the return for testing.
+        );
+    }
+
+    public function clearToken(): void
+    {
+        Cache::forget(self::CACHE_KEY);
+    }
+}
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,11 @@ class CachingTokenManager extends OAuth2TokenManager
     private const string CACHE_KEY = 'amazon_unique_token_cache_key'; // Use a unique cache key to avoid collisions with other cached data.
     private const int CACHE_TTL_SECONDS = 3300; // 55 minutes — 5 minutes less than Amazon's 60 minute token expiry
 
-    public function __construct(private readonly \Psr\SimpleCache\CacheInterface $cache)
-    {
-        parent::__construct();
+    public function __construct(
+        private readonly \Psr\SimpleCache\CacheInterface $cache,
+        OAuth2Config $config
+    ) {
+        parent::__construct($config);
     }
 
     public function getToken(): string

--- a/src/com/amazon/creators/api/DefaultApi.php
+++ b/src/com/amazon/creators/api/DefaultApi.php
@@ -225,7 +225,7 @@ class DefaultApi
             $this->cachedVersion = $currentVersion;
             $this->cachedAuthEndpoint = $currentAuthEndpoint;
         }
-        
+
         return $this->tokenManager;
     }
 
@@ -235,11 +235,11 @@ class DefaultApi
      * @param string $resourcePath The API resource path
      * @return array Array of headers
      */
-    private function buildAuthenticatedHeaders(string $resourcePath): array
+    protected function buildAuthenticatedHeaders(string $resourcePath): array
     {
         // Get OAuth2 token (creates/recreates token manager if needed)
         $token = $this->getOrCreateTokenManager()->getToken();
-        
+
         // Build OAuth2 headers - Version suffix only for v2.x (Cognito)
         $version = $this->config->getVersion();
         if (str_starts_with($version, "3.")) {
@@ -251,7 +251,7 @@ class DefaultApi
                 'Authorization' => "Bearer {$token}, Version {$version}"
             ];
         }
-        
+
         return $oauthHeaders;
     }
 
@@ -355,7 +355,7 @@ class DefaultApi
                     );
             }
 
-            
+
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -434,7 +434,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-        
+
 
             throw $e;
         }
@@ -536,7 +536,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getBrowseNodes, must conform to the pattern /.*\\S.*/.");
         }
-        
+
         // verify the required parameter 'getBrowseNodesRequestContent' is set
         if ($getBrowseNodesRequestContent === null || (is_array($getBrowseNodesRequestContent) && count($getBrowseNodesRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -723,7 +723,7 @@ class DefaultApi
                     );
             }
 
-            
+
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -802,7 +802,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-        
+
 
             throw $e;
         }
@@ -904,7 +904,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getFeed, must conform to the pattern /.*\\S.*/.");
         }
-        
+
         // verify the required parameter 'getFeedRequestContent' is set
         if ($getFeedRequestContent === null || (is_array($getFeedRequestContent) && count($getFeedRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -1091,7 +1091,7 @@ class DefaultApi
                     );
             }
 
-            
+
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -1170,7 +1170,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-        
+
 
             throw $e;
         }
@@ -1272,7 +1272,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getItems, must conform to the pattern /.*\\S.*/.");
         }
-        
+
         // verify the required parameter 'getItemsRequestContent' is set
         if ($getItemsRequestContent === null || (is_array($getItemsRequestContent) && count($getItemsRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -1459,7 +1459,7 @@ class DefaultApi
                     );
             }
 
-            
+
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -1538,7 +1538,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-        
+
 
             throw $e;
         }
@@ -1640,7 +1640,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getReport, must conform to the pattern /.*\\S.*/.");
         }
-        
+
         // verify the required parameter 'getReportRequestContent' is set
         if ($getReportRequestContent === null || (is_array($getReportRequestContent) && count($getReportRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -1827,7 +1827,7 @@ class DefaultApi
                     );
             }
 
-            
+
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -1906,7 +1906,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-        
+
 
             throw $e;
         }
@@ -2008,7 +2008,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getVariations, must conform to the pattern /.*\\S.*/.");
         }
-        
+
         // verify the required parameter 'getVariationsRequestContent' is set
         if ($getVariationsRequestContent === null || (is_array($getVariationsRequestContent) && count($getVariationsRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -2193,7 +2193,7 @@ class DefaultApi
                     );
             }
 
-            
+
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -2272,7 +2272,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-        
+
 
             throw $e;
         }
@@ -2371,7 +2371,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.listFeeds, must conform to the pattern /.*\\S.*/.");
         }
-        
+
 
         $resourcePath = '/catalog/v1/listFeeds';
         $formParams = [];
@@ -2542,7 +2542,7 @@ class DefaultApi
                     );
             }
 
-            
+
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -2621,7 +2621,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-        
+
 
             throw $e;
         }
@@ -2720,7 +2720,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.listReports, must conform to the pattern /.*\\S.*/.");
         }
-        
+
 
         $resourcePath = '/reports/v1/listReports';
         $formParams = [];
@@ -2893,7 +2893,7 @@ class DefaultApi
                     );
             }
 
-            
+
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -2972,7 +2972,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-        
+
 
             throw $e;
         }
@@ -3074,7 +3074,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.searchItems, must conform to the pattern /.*\\S.*/.");
         }
-        
+
 
 
         $resourcePath = '/catalog/v1/searchItems';

--- a/src/com/amazon/creators/api/DefaultApi.php
+++ b/src/com/amazon/creators/api/DefaultApi.php
@@ -225,7 +225,7 @@ class DefaultApi
             $this->cachedVersion = $currentVersion;
             $this->cachedAuthEndpoint = $currentAuthEndpoint;
         }
-
+        
         return $this->tokenManager;
     }
 
@@ -239,7 +239,7 @@ class DefaultApi
     {
         // Get OAuth2 token (creates/recreates token manager if needed)
         $token = $this->getOrCreateTokenManager()->getToken();
-
+        
         // Build OAuth2 headers - Version suffix only for v2.x (Cognito)
         $version = $this->config->getVersion();
         if (str_starts_with($version, "3.")) {
@@ -251,7 +251,7 @@ class DefaultApi
                 'Authorization' => "Bearer {$token}, Version {$version}"
             ];
         }
-
+        
         return $oauthHeaders;
     }
 
@@ -355,7 +355,7 @@ class DefaultApi
                     );
             }
 
-
+            
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -434,7 +434,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-
+        
 
             throw $e;
         }
@@ -536,7 +536,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getBrowseNodes, must conform to the pattern /.*\\S.*/.");
         }
-
+        
         // verify the required parameter 'getBrowseNodesRequestContent' is set
         if ($getBrowseNodesRequestContent === null || (is_array($getBrowseNodesRequestContent) && count($getBrowseNodesRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -723,7 +723,7 @@ class DefaultApi
                     );
             }
 
-
+            
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -802,7 +802,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-
+        
 
             throw $e;
         }
@@ -904,7 +904,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getFeed, must conform to the pattern /.*\\S.*/.");
         }
-
+        
         // verify the required parameter 'getFeedRequestContent' is set
         if ($getFeedRequestContent === null || (is_array($getFeedRequestContent) && count($getFeedRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -1091,7 +1091,7 @@ class DefaultApi
                     );
             }
 
-
+            
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -1170,7 +1170,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-
+        
 
             throw $e;
         }
@@ -1272,7 +1272,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getItems, must conform to the pattern /.*\\S.*/.");
         }
-
+        
         // verify the required parameter 'getItemsRequestContent' is set
         if ($getItemsRequestContent === null || (is_array($getItemsRequestContent) && count($getItemsRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -1459,7 +1459,7 @@ class DefaultApi
                     );
             }
 
-
+            
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -1538,7 +1538,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-
+        
 
             throw $e;
         }
@@ -1640,7 +1640,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getReport, must conform to the pattern /.*\\S.*/.");
         }
-
+        
         // verify the required parameter 'getReportRequestContent' is set
         if ($getReportRequestContent === null || (is_array($getReportRequestContent) && count($getReportRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -1827,7 +1827,7 @@ class DefaultApi
                     );
             }
 
-
+            
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -1906,7 +1906,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-
+        
 
             throw $e;
         }
@@ -2008,7 +2008,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.getVariations, must conform to the pattern /.*\\S.*/.");
         }
-
+        
         // verify the required parameter 'getVariationsRequestContent' is set
         if ($getVariationsRequestContent === null || (is_array($getVariationsRequestContent) && count($getVariationsRequestContent) === 0)) {
             throw new \InvalidArgumentException(
@@ -2193,7 +2193,7 @@ class DefaultApi
                     );
             }
 
-
+            
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -2272,7 +2272,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-
+        
 
             throw $e;
         }
@@ -2371,7 +2371,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.listFeeds, must conform to the pattern /.*\\S.*/.");
         }
-
+        
 
         $resourcePath = '/catalog/v1/listFeeds';
         $formParams = [];
@@ -2542,7 +2542,7 @@ class DefaultApi
                     );
             }
 
-
+            
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -2621,7 +2621,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-
+        
 
             throw $e;
         }
@@ -2720,7 +2720,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.listReports, must conform to the pattern /.*\\S.*/.");
         }
-
+        
 
         $resourcePath = '/reports/v1/listReports';
         $formParams = [];
@@ -2893,7 +2893,7 @@ class DefaultApi
                     );
             }
 
-
+            
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
@@ -2972,7 +2972,7 @@ class DefaultApi
                     $e->setResponseObject($data);
                     throw $e;
             }
-
+        
 
             throw $e;
         }
@@ -3074,7 +3074,7 @@ class DefaultApi
         if (!preg_match("/.*\\S.*/", $xMarketplace)) {
             throw new \InvalidArgumentException("invalid value for \"xMarketplace\" when calling DefaultApi.searchItems, must conform to the pattern /.*\\S.*/.");
         }
-
+        
 
 
         $resourcePath = '/catalog/v1/searchItems';


### PR DESCRIPTION
The default `OAuth2TokenManager` caches tokens in-memory on the `DefaultApi` instance. In a stateless PHP environment where `DefaultApi` is constructed per-request, this means a token endpoint call is made on _every_ API request. It is simple enough to fix this by injecting your own `OAuth2tokenManger` extension into `DefaultApi` and caching in your applications caching layer. However the `DefaultApi` method `getOrCreateTokenManger` called by `buildAuthenticatedHeaders` will overwrite any custom token manager. By exposing `buildAuthenticatedHeaders` as protected, callers can extend `DefaultApi` and inject their own token manager — such as one backed by a shared cache (Redis, APCu, etc.) — that holds the token for up to 55 minutes across requests, eliminating redundant auth calls.